### PR TITLE
OZ-193: Removed temporary FHIR2 module dependency override.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,6 @@
       <version>${commonreportsVersion}</version>
       <type>jar</type>
     </dependency>
-    <dependency>
-      <groupId>org.openmrs.module</groupId>
-      <artifactId>fhir2-omod</artifactId>
-      <version>1.10.0-20230509.193209-21</version>
-      <type>jar</type>
-    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-193