### PR TITLE
OZ-196: Fix the Gitpod instructions

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,6 +1,0 @@
-FROM gitpod/workspace-full
-
-RUN sudo apt-get update \
- && sudo apt-get install -y \
-    gettext-base \
- && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+    gettext-base \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,6 @@
-image:
-  file: .gitpod.dockerfile
 tasks:
   - name: Run Ozone FOSS
-    init: scripts/mvnw clean package
+    init: sudo apt-get update && sudo apt-get install -y gettext-base && sudo rm -rf /var/lib/apt/lists/* && scripts/mvnw clean package
     command: source target/go-to-scripts-dir.sh && ./start-demo.sh
 ports:
   - name: OpenMRS

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.dockerfile
 tasks:
   - name: Run Ozone FOSS
     init: scripts/mvnw clean package


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/OZ-196

---

`envsubst` tool is missing on Gitpod environment.
Install `gettext-base` package.

Could be done by providing a custom Gitpod Dockerfile but when providing custom Dockerfile instructions, Gitpod takes ages to run (as it builds the image beforehand). The above solution appears faster.

---

⚠️ 2 commits: make sure to **squash** when merging.