### PR TITLE
OZ-457: Update README to reference Nginx (and not Apache 2).

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It may take some time to setup Ozone for the first time, so hang tight :hourglas
 
 When ready Gitpod will launch the tab for OpenMRS 3.
 
-## (option 2) Try Ozone locally using the embedded Nginx Revers proxy
+## (option 2) Try Ozone locally using the embedded Nginx Reverse proxy
 
 Clone
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It may take some time to setup Ozone for the first time, so hang tight :hourglas
 
 When ready Gitpod will launch the tab for OpenMRS 3.
 
-## (option 2) Try Ozone locally using the embedded Apache 2 proxy
+## (option 2) Try Ozone locally using the embedded Nginx Revers proxy
 
 Clone
 ```bash


### PR DESCRIPTION
Update the README after the changes introduced by https://github.com/ozone-his/ozone-docker/pull/66