### PR TITLE
Update the quick install script to download Maven 3.9.10 instead of 3.9.6

### DIFF
--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -44,7 +44,7 @@ fi
 
 # Download Maven and install locally
 echo "$INFO Installing Maven $mavenVersion..."
-mavenVersion="3.9.6"
+mavenVersion="3.9.10"
 mvn=apache-maven-${mavenVersion}/bin/mvn
 if [ -f "$mvn" ]
 then


### PR DESCRIPTION
Refer to this message:
https://openmrs.slack.com/archives/C02PYQD5D0A/p1749565423017079

>It actually appears that 3.9.6 does not exist on that repo anymore.
Might need to use 3.9.10 instead.

