### PR TITLE
(fix) Exclude the concatenated.env file from the merge env files execution

### DIFF
--- a/maven-parent/pom.xml
+++ b/maven-parent/pom.xml
@@ -312,7 +312,7 @@
                   <target>
                     ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/concatenated.env</target>
                   <searchDir>${project.build.directory}/${project.artifactId}-${project.version}/run/docker</searchDir>
-                  <pattern>^(?!ozone-dir\.env$).*\.env</pattern>
+                  <pattern>^(?!ozone-dir\.env$|concatenated\.env$).*\.env</pattern>
                   <override>true</override>
                 </merge>
               </merges>


### PR DESCRIPTION
This PR addresses `System.IO.IOException: No space left on device` errors during the build process in Github Actions by excluding the `concatenated.env` file from the merge merge pattern.

cc @enyachoke @corneliouzbett @rbuisson 