### PR TITLE
OZ-838: Exclude `fhir2-2.5.0.omod` in favor of `fhir2-2.6.0-SNAPSHOT`

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -681,7 +681,7 @@
                   <fileset
                           dir="${project.build.directory}/distro-emr-configuration/sdk-distro/web/openmrs_modules">
                     <exclude name="authentication-*.omod"/>
-                    <exclude name="fhir2-2.2.0.omod"/>
+                    <exclude name="fhir2-2.5.0.omod"/>
                   </fileset>
                 </copy>
               </target>


### PR DESCRIPTION
This PR removes duplicate fhir2 OpenMRS module.