### PR TITLE
Improve `create_db.sh` script to load .`sql` files present in data/mysql folder

### DIFF
--- a/distro/data/mysql/create_db.sh
+++ b/distro/data/mysql/create_db.sh
@@ -10,7 +10,25 @@ set -e
 directory=/docker-entrypoint-initdb.d/db/
 if [ -d "${directory}" ]
 then
-    find ${directory}* -type f -execdir ls {} \; -execdir bash {} \;
+    find ${directory}* -type f | sort | while read -r f; do
+        echo "Processing: $f"
+        case "$f" in
+            *.sh)
+                bash "$f"
+                ;;
+            *.sql)
+                db_name=$(basename "$(dirname "$f")")
+                mysql -u root -p"${MYSQL_ROOT_PASSWORD}" "$db_name" < "$f"
+                ;;
+            *.sql.gz)
+                db_name=$(basename "$(dirname "$f")")
+                gunzip -c "$f" | mysql -u root -p"${MYSQL_ROOT_PASSWORD}" "$db_name"
+                ;;
+            *)
+                echo "Ignoring unsupported file type: $f"
+                ;;
+        esac
+    done
 else
     echo "Directory '${directory}' does not exist. No database to create. Exit 0."
 fi

--- a/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
Improved `create_db.sh` to be able to pick up `.sql` files present in `data/mysql/<dir>` for processing.