### PR TITLE
Install `openmrs` and pin `react-aria-components` + update Maven Wrapper distribution to `v3.9.15`

### DIFF
--- a/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
+++ b/scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy
@@ -54,8 +54,35 @@ if (shouldBuildFrontend) {
     }
 
     log.info("Running build command...")
+    def packageJsonFile = new File(outputDirectory, "package.json")
+    log.info("Writing package.json with openmrs dependency and overrides to ${packageJsonFile.getAbsolutePath()}...")
+    packageJsonFile.text = """\
+    {
+      "name": "openmrs-frontend-build",
+      "version": "1.0.0",
+      "dependencies": {
+        "openmrs": "${openmrsVersion}"
+      },
+      "overrides": {
+        "react-aria-components": "1.8.0"
+      }
+    }
+    """
 
-    def buildProcess = "npx --legacy-peer-deps openmrs@${openmrsVersion} build --config-url \$SPA_CONFIG_URLS --default-locale \$SPA_DEFAULT_LOCALE --target ${outputDirectory}".execute()
+    // Install openmrs and all dependencies locally so webpack can resolve overridden packages correctly.
+    log.info("Installing openmrs@${openmrsVersion} and dependencies with overrides in ${outputDirectory}...")
+    def installProcess = "npm install --legacy-peer-deps".execute(null, new File(outputDirectory))
+    installProcess.consumeProcessOutput(System.out, System.err)
+    installProcess.waitFor()
+
+    if (installProcess.exitValue() != 0) {
+        throw new RuntimeException("Failed to install openmrs and dependencies. See previous messages for details.")
+    }
+
+    log.info("Using OpenMRS Frontend Core Version for build: ${openmrsVersion}")
+
+    // Run the build using the locally installed openmrs binary so it picks up the local node_modules with overrides.
+    def buildProcess = "${outputDirectory}/node_modules/.bin/openmrs build --config-url \$SPA_CONFIG_URLS --default-locale \$SPA_DEFAULT_LOCALE --target ${outputDirectory}".execute()
     buildProcess.consumeProcessOutput(System.out, System.err)
     buildProcess.waitFor()
 


### PR DESCRIPTION
This PR:
- Updates Maven Wrapper distribution to `v3.9.15`.
- Install `openmrs` in the frontend output directory and run the build from
the local binary instead of npx. Also add an override for
`react-aria-components@1.8.0` so transitive `react-aria` packages resolve
correctly in CI.