### PR TITLE
Temporarily disable OpenMRS frontend build due to unresolved dependencies

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -888,19 +888,20 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <executions>
-          <execution>
-            <id>Build OpenMRS Frontend</id>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <configuration>
-              <scripts>
-                <script>
-                  file://${project.basedir}/../scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>
-              </scripts>
-            </configuration>
-          </execution>
+          <!-- Build OpenMRS Frontend - Temporarily disabled because the frontend build is failing due unresolved dependencies. Also, it's unnecessary until we have frontend customizations. -->
+<!--          <execution>-->
+<!--            <id>Build OpenMRS Frontend</id>-->
+<!--            <goals>-->
+<!--              <goal>execute</goal>-->
+<!--            </goals>-->
+<!--            <phase>process-resources</phase>-->
+<!--            <configuration>-->
+<!--              <scripts>-->
+<!--                <script>-->
+<!--                  file://${project.basedir}/../scripts/openmrs/frontend_assembly/build-openmrs-frontend.groovy</script>-->
+<!--              </scripts>-->
+<!--            </configuration>-->
+<!--          </execution>-->
 
           <execution>
             <id>Generate Ozone Info JSON file</id>

--- a/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/maven-archetype/src/test/resources/projects/it-basic/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
+++ b/samples/ozone-with-distro-properties/src/test/resources/projects/it-ozone-with-distro-properties/reference/scripts/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
This PR temporarily disables OpenMRS frontend build due to unresolved dependencies.